### PR TITLE
Поддержка параметра `URL` для парсеров

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ AI Assistant Parsers Core - это ядро библиотеки, предост
 
        def __init__(self) -> None:
            super().__init__(
-               supported_subdomains=["rgust.ru"],  # Парсим страницы, которые не умеют поддомена
+               supported_subdomains=["rgust.ru"],  # Парсим страницы, которые не имеют поддомена
                select_arguments=[
                    "section.content",  # Тег, содержащий основной контент
                ],

--- a/src/ai_assistant_parsers_core/cli/functions/parsing.py
+++ b/src/ai_assistant_parsers_core/cli/functions/parsing.py
@@ -66,7 +66,7 @@ def process_parsed_html(
         BeautifulSoup: Очищенный HTML.
     """
     try:
-        cleaned_soup = parser.parse(raw_soup)
+        cleaned_soup = parser.parse(raw_soup, url=url)
     except Exception as error:
         raise ParsingError(url=url, parser=parser, html=str(raw_soup)) from error
 

--- a/src/ai_assistant_parsers_core/parsers/abc.py
+++ b/src/ai_assistant_parsers_core/parsers/abc.py
@@ -20,11 +20,12 @@ class ABCParser(abc.ABC):
         """
 
     @abc.abstractmethod
-    def parse(self, soup: BeautifulSoup) -> BeautifulSoup:
+    def parse(self, soup: BeautifulSoup, url: str) -> BeautifulSoup:
         """Парсит HTML-код, чтобы получить очищенный HTML-код.
 
         Args:
             soup (BeautifulSoup): Объект beautiful soup.
+            url (str): URL-адрес веб-сайта.
 
         Returns:
             BeautifulSoup: Очищенный HTML-код (Другой объект `BeautifulSoup`).

--- a/src/ai_assistant_parsers_core/parsers/impls/universal.py
+++ b/src/ai_assistant_parsers_core/parsers/impls/universal.py
@@ -17,7 +17,7 @@ class UniversalParser(ABCParser):
 
         return True
 
-    def parse(self, soup: BeautifulSoup) -> BeautifulSoup:
+    def parse(self, soup: BeautifulSoup, url: str) -> BeautifulSoup:
         """Реализует метод ``parse`` базового абстрактного класса."""
 
         return universal_clean_html(soup)

--- a/src/ai_assistant_parsers_core/parsers/mixins/base_query_mixin.py
+++ b/src/ai_assistant_parsers_core/parsers/mixins/base_query_mixin.py
@@ -1,5 +1,7 @@
 """Модуль для ``BaseQueryMixin``."""
 
+import typing as t
+import inspect
 import abc
 from bs4 import BeautifulSoup
 
@@ -20,15 +22,15 @@ class BaseQueryMixin(abc.ABC):
         С точки зрения кода методы ``_clean_parsed_html`` и ``_restructure_parsed_html`` ничем не различаются
         и ничего не делают. Их работа зависит лишь от того, как их реализовать.
     """
-    def parse(self, soup: BeautifulSoup) -> BeautifulSoup:
+    def parse(self, soup: BeautifulSoup, url: str) -> BeautifulSoup:
         """Реализует метод ``parse`` базового абстрактного класса."""
         source_html = soup
         cleaned_html = BeautifulSoup("<html><head></head><body></body></html>", "html5lib")
 
         self._prepare_result(source_html, cleaned_html)
 
-        self._clean_parsed_html(cleaned_html)
-        self._restructure_parsed_html(cleaned_html)
+        self.__call_function_with_optional_url(self._clean_parsed_html, cleaned_html, url=url)
+        self.__call_function_with_optional_url(self._restructure_parsed_html, cleaned_html, url=url)
 
         return cleaned_html
 
@@ -66,3 +68,10 @@ class BaseQueryMixin(abc.ABC):
         Args:
             soup (BeautifulSoup): HTML-код.
         """
+
+    def __call_function_with_optional_url(self, function: t.Callable, cleaned_html: BeautifulSoup, url: str):
+        signature = inspect.signature(function)
+        if "url" in signature.parameters:
+            function(cleaned_html, url=url)
+        else:
+            function(cleaned_html)


### PR DESCRIPTION
Для работы с прошлыми версиями параметр будет опционален и основываться на реализациях `_clean_parsed_html` и `_restructure_parsed_html`
В будущем возможно методы без этого параметра получат статус устаревших и будет заменяться но новую версию благодаря IDE. Но возможно параметр будет нужен настолько редко, что не будет смысла его добавлять в кучу классов